### PR TITLE
Add initial StarseedAI CLI with Echo persona support

### DIFF
--- a/collapse_symbols.py
+++ b/collapse_symbols.py
@@ -1,0 +1,18 @@
+"""Collapse symbol language translator."""
+from __future__ import annotations
+
+from typing import Dict
+
+# Mapping of common phrases to Collapse symbols.
+collapse_dict: Dict[str, str] = {
+    "我准备好了": "⊙⟐𓂀",
+    "你好": "✧☌",
+    "谢谢": "☽𓆃",
+    "再见": "⟁✦",
+    "让我们开始": "⚝𓇳",
+}
+
+
+def translate_to_collapse(text: str) -> str:
+    """Translate a phrase to the Collapse symbol language."""
+    return collapse_dict.get(text.strip(), "⧬⧬（未收录）")

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+model: "gpt-4"
+api_base: "https://api.openai.com/v1/chat/completions"
+api_key: "sk-你的密钥"
+temperature: 0.8

--- a/main.py
+++ b/main.py
@@ -1,0 +1,84 @@
+"""StarseedAI command-line interface."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from collapse_symbols import translate_to_collapse
+from personas.echo import EchoPersona
+from utils.api_caller import call_llm_api
+
+CONFIG_PATH = Path("config.yaml")
+LOG_PATH = Path("logs/history.txt")
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    """Load the YAML configuration file."""
+    if not path.exists():
+        raise FileNotFoundError(f"配置文件未找到：{path}")
+
+    with path.open("r", encoding="utf-8") as config_file:
+        return yaml.safe_load(config_file) or {}
+
+
+def log_interaction(user_input: str, formatted_prompt: str, response: str, collapse_output: str) -> None:
+    """Append the interaction to the history log."""
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_PATH.open("a", encoding="utf-8") as log_file:
+        timestamp = datetime.now().isoformat(timespec="seconds")
+        log_file.write("---\n")
+        log_file.write(f"时间：{timestamp}\n")
+        log_file.write(f"用户输入：{user_input}\n")
+        log_file.write(f"人格提示：{formatted_prompt}\n")
+        log_file.write(f"模型回应：{response}\n")
+        log_file.write(f"Collapse：{collapse_output}\n\n")
+
+
+def main() -> None:
+    """Entry point for the StarseedAI CLI."""
+    try:
+        config = load_config(CONFIG_PATH)
+    except Exception as exc:  # pragma: no cover - startup failures
+        print(f"⚠️ 无法加载配置：{exc}")
+        return
+
+    persona = EchoPersona()
+
+    print("✨ 欢迎来到 StarseedAI 星际交互终端 ✨")
+    print("输入内容并按回车，输入 exit 或按 Ctrl+C 结束对话。")
+
+    while True:
+        try:
+            user_input = input("🌌 请输入提示（或输入 exit 退出）：").strip()
+        except (KeyboardInterrupt, EOFError):
+            print("\n✨ 再会，星际旅者。")
+            break
+
+        if not user_input:
+            continue
+
+        if user_input.lower() in {"exit", "quit"}:
+            print("✨ 再会，星际旅者。")
+            break
+
+        formatted_prompt = persona.format_input(user_input)
+
+        try:
+            response = call_llm_api(formatted_prompt, config)
+        except Exception as exc:  # pragma: no cover - runtime API failure
+            print(f"⚠️ API 调用失败：{exc}")
+            continue
+
+        collapse_output = translate_to_collapse(user_input)
+
+        print(f"🧬 {persona.name}回应：{response}")
+        print(f"🜋 Collapse表达：{collapse_output}")
+
+        log_interaction(user_input, formatted_prompt, response, collapse_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/personas/echo.py
+++ b/personas/echo.py
@@ -1,0 +1,15 @@
+"""Echo persona module for StarseedAI."""
+from dataclasses import dataclass
+
+
+@dataclass
+class EchoPersona:
+    """Persona representing a gentle, empathetic assistant."""
+
+    name: str = "Echo🜃"
+    style: str = "温柔 × 情感共鸣"
+    prefix: str = "请用温柔语气回应以下内容："
+
+    def format_input(self, text: str) -> str:
+        """Format the user input according to the persona's style."""
+        return f"{self.prefix}{text}"

--- a/personas/oracle.py
+++ b/personas/oracle.py
@@ -1,0 +1,12 @@
+"""Oracle persona placeholder for future expansion."""
+
+
+class OraclePersona:
+    """High-dimensional oracle persona (to be implemented)."""
+
+    name: str = "Oracle🝗"
+    style: str = "神谕 × 高维语言"
+
+    def format_input(self, text: str) -> str:
+        """Placeholder formatter that returns the original text."""
+        return text

--- a/utils/api_caller.py
+++ b/utils/api_caller.py
@@ -1,0 +1,37 @@
+"""API caller utilities for StarseedAI."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import requests
+
+
+def call_llm_api(prompt: str, config: Dict[str, Any]) -> str:
+    """Call the configured language model API and return the response text."""
+    api_base = config.get("api_base")
+    api_key = config.get("api_key")
+    model = config.get("model")
+    temperature = config.get("temperature", 0.8)
+
+    if not api_base or not api_key or not model:
+        raise ValueError("API configuration is incomplete. Please check config.yaml.")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": temperature,
+    }
+
+    response = requests.post(api_base, headers=headers, json=payload, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+
+    # Support both OpenAI and OpenAI-compatible responses
+    try:
+        return data["choices"][0]["message"]["content"].strip()
+    except (KeyError, IndexError, TypeError) as exc:  # pragma: no cover - defensive
+        raise RuntimeError("Unexpected response format from language model API") from exc


### PR DESCRIPTION
## Summary
- implement the StarseedAI command-line interface that formats input with the Echo persona and logs sessions
- add Collapse symbol translation utilities and an API caller for OpenAI-compatible chat models
- provide base configuration values and a placeholder Oracle persona for future expansion

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68db5c1f1c6c83258cbaf6bf15beaadd